### PR TITLE
Updated default port to match the actual used port

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ### Usage
 
-- Port env variable: `HTTP_SERVER_PORT` default `4200`
+- Port env variable: `HTTP_SERVER_PORT` default `8043`
 - Public folder env variable: `PUBLIC_FOLDER_PATH` default `/public`
 - Default fallback set to `/index.html`
 


### PR DESCRIPTION
In the README.md there were two defaults mentioned, 8043 and 4200. Pulled the image and tested, dhlab-basel/docker-http-server is using 8043 as the default.